### PR TITLE
Fix number_of_objectified_morphisms_in_data_structure_of_morphism

### DIFF
--- a/examples/PrecompileSliceCategory.g
+++ b/examples/PrecompileSliceCategory.g
@@ -41,7 +41,7 @@ CapJitPrecompileCategoryAndCompareResult(
     number_of_objectified_objects_in_data_structure_of_object := 3,
     number_of_objectified_morphisms_in_data_structure_of_object := 1,
     number_of_objectified_objects_in_data_structure_of_morphism := 6,
-    number_of_objectified_morphisms_in_data_structure_of_morphism := 3
+    number_of_objectified_morphisms_in_data_structure_of_morphism := 4
 );
 
 #! @EndExample


### PR DESCRIPTION
A morphism is constructed from an underlying morphism, two objects which are also given by underlying morphisms, and has to objectified itself. This gives a total of 4 morphisms.